### PR TITLE
Add two-point voltage correction option

### DIFF
--- a/Silverware/src/config.h
+++ b/Silverware/src/config.h
@@ -133,8 +133,19 @@
 #define HYST 0.10
 
 // *************automatic voltage telemetry correction/calibration factor - change the values below if voltage telemetry is inaccurate
+// Corrects for an offset error in the telemetry measurement (same offset across the battery voltage range)
 #define ACTUAL_BATTERY_VOLTAGE 4.20
 #define REPORTED_TELEMETRY_VOLTAGE 4.20
+
+// *************two-point automatic voltage telemetry correction/calibration factor - change the values below if voltage telemetry is inaccurate
+// Use this method when the difference at the high end is different than the difference at the low end. Corrects both slope and offset of the _assumed_ linear error.
+#define USE_TWO_POINT_VOLTAGE_CORRECTION
+#define ACTUAL_BATTERY_VOLTAGE_LO 3.60
+#define ACTUAL_BATTERY_VOLTAGE_HI 4.20
+#define REPORTED_TELEMETRY_VOLTAGE_LO 3.60
+#define REPORTED_TELEMETRY_VOLTAGE_HI 4.20
+#define ACTUAL_BATTERY_VOLTAGE_RANGE (ACTUAL_BATTERY_VOLTAGE_HI - ACTUAL_BATTERY_VOLTAGE_LO)
+#define REPORTED_TELEMETRY_VOLTAGE_RANGE (REPORTED_TELEMETRY_VOLTAGE_HI - REPORTED_TELEMETRY_VOLTAGE_LO)
 
 
 

--- a/Silverware/src/drv_adc.c
+++ b/Silverware/src/drv_adc.c
@@ -101,7 +101,12 @@ float adc_read(int channel)
 		#ifdef DEBUG
 		lpf(&debug.adcfilt , (float) adcarray[0] , 0.998);
 		#endif	
+		#ifdef USE_TWO_POINT_VOLTAGE_CORRECTION
+		// CorrectedValue = (((RawValue – RawLow) * ReferenceRange) / RawRange) + ReferenceLow
+		return ( ( ((float) adcarray[0] * (float) ADC_SCALEFACTOR) - (float) REPORTED_TELEMETRY_VOLTAGE_LO ) * ((float) ACTUAL_BATTERY_VOLTAGE_RANGE / (float) REPORTED_TELEMETRY_VOLTAGE_RANGE) ) + (float) ACTUAL_BATTERY_VOLTAGE_LO;
+		#else
 		return (float) adcarray[0] * ((float) (ADC_SCALEFACTOR*(ACTUAL_BATTERY_VOLTAGE/REPORTED_TELEMETRY_VOLTAGE))) ;
+		#endif
 		
 		case 1:
         #ifdef DEBUG


### PR DESCRIPTION
Same as previous, just wanted to get my repo updated with your latest and had to switch the branch my change was on...so new pull request (there was likely a better way to do this git stuff, though!).

For reference, here is the previous pull request's comment history:

With features like this (Vbat PID compensation), it seems like it could be important to get the battery voltage calibrated correctly. I tried using the automatic voltage calibration settings in config.h, but noticed that I could only get the voltage calibrated for one side of the battery or the other - at high voltage or low voltage. There was not just an offset, but a slope difference, too (and probably a curve, too, really...).
Until now, I used the settings on my Taranis Q X7 to calibrate out that slope and offset, as @chime13 and @ian444 mentioned earlier in the MMW NFE thread (something like the Taranis settings mentioned before of "Scale: 10.4 and Offset: -2.62 but with the default scalefactor of 0.001364."). Also, I noticed that I had to tune it different for my E011 board than my Beta65S Lite board.
This weekend, I added a feature to use a two-point battery voltage correction to config.h and drv_adc.c. It accomplishes the same result as the Taranis correction, but will work with any transmitter and allows the corrected values to be used for LVC, VBAT PID compensation, etc. I take measurements with a multimeter and then read the telemetry value for two points - with a full battery and a weak battery (say, 4.2V and 3.6V). Plug all four of those values into config.h and it will correct the slope and offset of the battery voltage "curve" (it is actually a linear correction).
For Taranis people: now my Taranis voltage scale factor is set to 6.6 (which is what it should be for the 3.3V reference) and the offset is 0.0.
My two boards, an E011 and Beta65S Lite actually need different correction factors. I already build different binaries for them, so it's not a big deal to keep their correction factors different. I don't know if all E011 boards are similar and can share correction factors, etc.

silver13 commented
How much is the battery voltage off by? I'd like to find the cause of this issue, some small offset ( 2% ) could be from tolerances, but more could be from an error somewhere.
The regulators can change voltage depending on input, but even that should be covered by the existing code

brianquad commented
For my E011, it is around 0.10 off on a full battery and 0.23 off for a spent battery.
Here is the data I took for my E011 board:
MultiMeter | Telemetry | Difference
4.12 | 4.22 | 0.10
4.13 | 4.22 | 0.09
3.70 | 3.88 | 0.18
3.79 | 4.01 | 0.22
3.72 | 3.96 | 0.24
4.00 | 4.12 | 0.12
And here is the data I took from my Beta 65S Lite board (using HV batteries):
MultiMeter | Telemetry | Difference
4.39 | 4.40 | 0.01
4.34 | 4.37 | 0.03
4.38 | 4.40 | 0.02
4.35 | 4.37 | 0.02
3.71 | 3.96 | 0.25
3.70 | 3.96 | 0.26
3.69 | 3.91 | 0.22
I admit that I have not examined the code much to see how the battery voltage is handled or how it should work, so I could just be treating the symptom :-) Let me know if I can track down a problem in any way!

silver13 commented
Thanks, it looks like under 10%, but it's strange how it gets worse at low values
the code uses the adc value, then attempts to compensate it by measuring vcc and using the internal calibration of the adc, which is saved in flash at factory production.
The internal compensation was added because the vreg can have a large tolerance, especially when the battery voltage changes
you could look at the compensation value in debug mode, should be equal to 1.178 if the vcc supplied to mcu is 2.8. You could also force it to disable the feature by setting it to return 1.0 .
https://github.com/NotFastEnuf/E011-BWHOOP-H8-Silverware/blob/master/Silverware/src/drv_adc.c#L108

brianquad commented
chime13 on MMW pointed out that I missed a warning in compiling drv_adc.h. I've updated the code to explicitly cast all of the constants to floats to avoid the implicit conversion to doubles.

NotFastEnuf commented
Just wanted to check and make sure you were comparing your multi meter readings against the actual moment to moment telemetry voltage and not the averaged one. Thanks brianquad

NotFastEnuf commented
Thanks. I'll test it out and merge it in. Looking forward to what you come up with next Brian!