### PR TITLE
Implemented betaflight rates

### DIFF
--- a/Silverware/src/config.h
+++ b/Silverware/src/config.h
@@ -42,6 +42,14 @@
 #define ANGLE_EXPO_PITCH 0.0
 #define ANGLE_EXPO_YAW 0.55
 
+//#define BETAFLIGHT_RATES
+#define BF_RC_RATE_ROLL 1.00
+#define BF_RC_RATE_PITCH 1.00
+#define BF_RC_RATE_YAW 1.00
+#define BF_SUPER_EXPO_ROLL 0.70
+#define BF_SUPER_EXPO_PITCH 0.70
+#define BF_SUPER_EXPO_YAW 0.70
+
 // *************transmitter stick adjustable deadband for roll/pitch/yaw
 // *************.01f = 1% of stick range - comment out to disable
 #define STICKS_DEADBAND .01f


### PR DESCRIPTION
I copied this piece of code from betaflight a long time ago, it is working well.
I think it is a really good addition, as currently silverware is lacking the super expo feel. It is quite different than standard expo.

Small how-to:

1. Uncomment BETAFLIGHT_RATES define in config.h
2. Set your rates/super expo + angle/acro expo.
3. Save and flash your quad.

To disable simply comment out BETAFLIGHT_RATES in config.h