### PR TITLE
Fix CH_PIT_TRIM when USE_STOCK_TX is defined

### DIFF
--- a/Silverware/src/rx_bayang_ble_app.c
+++ b/Silverware/src/rx_bayang_ble_app.c
@@ -1030,12 +1030,12 @@ char trims[4];
 				      }
 #else			
 // this share the same numbers to the above CH_PIT_TRIM etc		 					
+					aux[CH_INV] = (rxdata[3] & 0x80) ? 1 : 0; // inverted flag
 					aux[CH_VID] = (rxdata[2] & 0x10) ? 1 : 0;
 												
 					aux[CH_PIC] = (rxdata[2] & 0x20) ? 1 : 0;						
 #endif
 							
-				aux[CH_INV] = (rxdata[3] & 0x80)?1:0; // inverted flag
 							
 			    aux[CH_FLIP] = (rxdata[2] & 0x08) ? 1 : 0;
 


### PR DESCRIPTION
When using "toy transmitter" one might want to assign pitch trim
buttons to do something useful. Do not override it.

The same issue is present in all the copies of decodepacket() in all
rx_* files, including the h8_dual firmware in another repository.