### PR TITLE
Fix dshot_dma driver beep command

### DIFF
--- a/Silverware/src/drv_dshot_dma.c
+++ b/Silverware/src/drv_dshot_dma.c
@@ -498,10 +498,10 @@ void motorbeep()
 			}
 
 			if ( beep_command != 0 ) {
-				make_packet( 0, beep_command, false );
-				make_packet( 1, beep_command, false );
-				make_packet( 2, beep_command, false );
-				make_packet( 3, beep_command, false );
+				make_packet( 0, beep_command, true );
+				make_packet( 1, beep_command, true );
+				make_packet( 2, beep_command, true );
+				make_packet( 3, beep_command, true );
 				dshot_dma_start();
 			}
 		}


### PR DESCRIPTION
I have not tested this (I currently have no compatible hardware to do so). I am just creating a pull request for the fix that Markus Gritsch suggested (so it doesn't get lost/missed):
https://www.rcgroups.com/forums/showpost.php?p=41265423&postcount=3222
